### PR TITLE
fix stream position in failing test

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -206,7 +206,7 @@ describe('GET /events/:id', () => {
                 expect(res.body.data).toEqual(TEST_EVENT_2.data);
                 expect(res.body.metadata).toEqual(TEST_EVENT_2.metadata);
                 expect(res.body.streamPosition).toBe(1);
-                expect(res.body.globalPosition).toBe(1);
+                expect(res.body.globalPosition).toBe(2);
             });
     });
 });

--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -205,7 +205,7 @@ describe('GET /events/:id', () => {
                 expect(res.body.streamName).toBe(TEST_EVENT_2.streamName);
                 expect(res.body.data).toEqual(TEST_EVENT_2.data);
                 expect(res.body.metadata).toEqual(TEST_EVENT_2.metadata);
-                expect(res.body.streamPosition).toBe(0);
+                expect(res.body.streamPosition).toBe(1);
                 expect(res.body.globalPosition).toBe(1);
             });
     });


### PR DESCRIPTION
Underlying library changed logic to start indexing both stream and global position from 1